### PR TITLE
Simplify the point class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 # create a new executable with the same name as the project
 add_executable(${PROJECT_NAME}
   src/engine/basics/log.hxx
-  src/engine/basics/point.cxx
   src/engine/basics/point.hxx
   src/engine/basics/resources.cxx
   src/engine/basics/resources.hxx

--- a/src/engine/basics/point.cxx
+++ b/src/engine/basics/point.cxx
@@ -1,7 +1,0 @@
-#include "point.hxx"
-
-void Point::setCoords(int x, int y, int height)
-{
-  _x = x;
-  _y = y;
-}

--- a/src/engine/basics/point.hxx
+++ b/src/engine/basics/point.hxx
@@ -3,44 +3,27 @@
 #ifndef POINT_HXX_
 #define POINT_HXX_
 
-class Point
+struct Point
 {
-public:
-  Point() : _x(0), _y(0), _z(0), _height(0) { };
-  Point(int x, int y) : _x(x), _y(y), _z(0), _height(0) { };
-  Point(int x, int y, int z) : _x(x), _y(y), _z(z), _height(0) { };
-  Point(int x, int y, int z, int height) : _x(x), _y(y), _z(z), _height(height) { };
-  ~Point() = default;
+  /**
+   * The x coordinate.
+   */
+  int x;
 
-  // set point to Coordinates
-  void setCoords(int x, int y, int height = 0);
+  /**
+   * The y coordinate.
+   */
+  int y;
 
-  /** Sets the X Coordinate*/
-  void setX(int x) { _x = x; };
+  /**
+   * The z coordinate.
+   */
+  int z;
 
-  /** Sets the Y Coordinate*/
-  void setY(int y) { _y = y; };;
-
-  /** Sets the Z Coordinate (Drawing Order)*/
-  void setZ(int z) { _z = z; };;
-
-  /** Sets the Heightlevel (Tileheight)*/
-  void setHeight(int height) { _height = height; };
-
-  /** Gets the X Coordinate*/
-  int getX() const { return _x; };
-  
-  /** Gets the Y Coordinate*/
-  int getY() const { return _y; };
-
-  /** Gets the Z Coordinate (Drawing Order)*/
-  int getZ() const  { return _z; };
-  
-  /** Gets the Heightlevel (Tileheight)*/
-  int getHeight() const { return _height; };
-
-private:
-  int _x, _y, _z, _height;
+  /**
+   * The height level.
+   */
+  int height;
 };
 
 #endif

--- a/src/engine/basics/point.hxx
+++ b/src/engine/basics/point.hxx
@@ -3,8 +3,6 @@
 #ifndef POINT_HXX_
 #define POINT_HXX_
 
-//#include "resources.hxx"
-
 class Point
 {
 public:

--- a/src/engine/basics/resources.cxx
+++ b/src/engine/basics/resources.cxx
@@ -137,25 +137,26 @@ Point Resources::convertIsoToScreenCoordinates(const Point& isoCoordinates, bool
 {
   int x, y;
 
-  int height = isoCoordinates.getHeight();
+  int height = isoCoordinates.height;
   int heightOffset = 20;
 
   if (calcWithoutOffset)
   {
-    x = static_cast<int>((_tileSize * _zoomLevel * isoCoordinates.getX() * 0.5)  + (_tileSize * _zoomLevel * isoCoordinates.getY() * 0.5));
-    y = static_cast<int>((_tileSize * _zoomLevel * isoCoordinates.getX() * 0.25) - (_tileSize * _zoomLevel * isoCoordinates.getY() * 0.25));
+    x = static_cast<int>((_tileSize * _zoomLevel * isoCoordinates.x * 0.5)  + (_tileSize * _zoomLevel * isoCoordinates.y * 0.5));
+    y = static_cast<int>((_tileSize * _zoomLevel * isoCoordinates.x * 0.25) - (_tileSize * _zoomLevel * isoCoordinates.y * 0.25));
   }
   else
   {
-    x = static_cast<int>((_tileSize * _zoomLevel * isoCoordinates.getX() * 0.5)  + (_tileSize * _zoomLevel * isoCoordinates.getY() * 0.5)  - _cameraOffset.getX());
-    y = static_cast<int>((_tileSize * _zoomLevel * isoCoordinates.getX() * 0.25) - (_tileSize * _zoomLevel * isoCoordinates.getY() * 0.25) - _cameraOffset.getY());
+    x = static_cast<int>((_tileSize * _zoomLevel * isoCoordinates.x * 0.5)  + (_tileSize * _zoomLevel * isoCoordinates.y * 0.5)  - _cameraOffset.x);
+    y = static_cast<int>((_tileSize * _zoomLevel * isoCoordinates.x * 0.25) - (_tileSize * _zoomLevel * isoCoordinates.y * 0.25) - _cameraOffset.y);
   }
   
   if (height > 0)
   {
     y = static_cast<int>(y - ((_tileSize - heightOffset) * height * _zoomLevel));
   }
-  return Point (x, y);
+
+  return {x, y, 0, 0};
 }
 
 // Temporary function that writes a json file and will be removed later (for debug purposes only)

--- a/src/engine/basics/vectorMatrix.cxx
+++ b/src/engine/basics/vectorMatrix.cxx
@@ -18,39 +18,39 @@ void vectorMatrix::initCells()
     {
       z++;
       //_cellMatrix.emplace(_cellMatrix.begin() + x * _columns + y,std::make_unique<Cell>(Point(x, y, z)));
-      _cellMatrix[x * _columns + y] = std::make_shared<Cell>(Point(x, y, z));
+      _cellMatrix[x * _columns + y] = std::make_shared<Cell>(Point{x, y, z, 0});
     }
   }
 }
 
 void vectorMatrix::increaseHeightOfCell (const Point& isoCoordinates)
 {
-  int height = _cellMatrix[isoCoordinates.getX() * _columns + isoCoordinates.getY()]->getCoordinates().getHeight();
+  int height = _cellMatrix[isoCoordinates.x * _columns + isoCoordinates.y]->getCoordinates().height;
 
   if ( height < Resources::settings.maxElevationHeight )
   {
-    _cellMatrix[isoCoordinates.getX() * _columns + isoCoordinates.getY()]->increaseHeightOfCell();
-    drawSurroundingTiles(_cellMatrix[isoCoordinates.getX() * _columns + isoCoordinates.getY()]->getCoordinates());
+    _cellMatrix[isoCoordinates.x * _columns + isoCoordinates.y]->increaseHeightOfCell();
+    drawSurroundingTiles(_cellMatrix[isoCoordinates.x * _columns + isoCoordinates.y]->getCoordinates());
   }
 }
 
 void vectorMatrix::decreaseHeightOfCell(const Point& isoCoordinates)
 {
-  int height = _cellMatrix[isoCoordinates.getX() * _columns + isoCoordinates.getY()]->getCoordinates().getHeight();
+  int height = _cellMatrix[isoCoordinates.x * _columns + isoCoordinates.y]->getCoordinates().height;
 
   if ( height > 0 )
   {
-    _cellMatrix[isoCoordinates.getX() * _columns + isoCoordinates.getY()]->decreaseHeightOfCell();
-    drawSurroundingTiles(_cellMatrix[isoCoordinates.getX() * _columns + isoCoordinates.getY()]->getCoordinates());
+    _cellMatrix[isoCoordinates.x * _columns + isoCoordinates.y]->decreaseHeightOfCell();
+    drawSurroundingTiles(_cellMatrix[isoCoordinates.x * _columns + isoCoordinates.y]->getCoordinates());
   }
 }
 
 void vectorMatrix::drawSurroundingTiles(const Point& isoCoordinates)
 {
-  int tileHeight = _cellMatrix[isoCoordinates.getX() * _columns + isoCoordinates.getY()]->getCoordinates().getHeight();
+  int tileHeight = _cellMatrix[isoCoordinates.x * _columns + isoCoordinates.y]->getCoordinates().height;
   int i = 0;
-  int x = isoCoordinates.getX();
-  int y = isoCoordinates.getY();
+  int x = isoCoordinates.x;
+  int y = isoCoordinates.y;
 
   std::pair<int, int> adjs[9] = {
     std::make_pair(x - 1, y - 1),    // 6 = 2^6 = 64  = BOTTOM LEFT
@@ -73,13 +73,13 @@ void vectorMatrix::drawSurroundingTiles(const Point& isoCoordinates)
         Point currentCoords = _cellMatrix[it.first * _columns + it.second]->getCoordinates();
 
         // there can't be a height difference greater then 1 between two map cells.
-        if ( tileHeight - _cellMatrix[it.first * _columns + it.second]->getCoordinates().getHeight() > 1
+        if ( tileHeight - _cellMatrix[it.first * _columns + it.second]->getCoordinates().height > 1
         &&   Resources::getTerrainEditMode() == Resources::TERRAIN_RAISE
         &&   i % 2 )
         {
           increaseHeightOfCell(currentCoords);
         }
-        else if ( tileHeight - _cellMatrix[it.first * _columns + it.second]->getCoordinates().getHeight() < -1
+        else if ( tileHeight - _cellMatrix[it.first * _columns + it.second]->getCoordinates().height < -1
         &&        Resources::getTerrainEditMode() == Resources::TERRAIN_LOWER
         &&        i % 2 )
         {
@@ -95,12 +95,12 @@ void vectorMatrix::drawSurroundingTiles(const Point& isoCoordinates)
 void vectorMatrix::determineTileIDOfCell(const Point& isoCoordinates)
 {
   unsigned int _elevatedTilePosition = 0;
-  int tileHeight = _cellMatrix[isoCoordinates.getX() * _columns + isoCoordinates.getY()]->getCoordinates().getHeight();
+  int tileHeight = _cellMatrix[isoCoordinates.x * _columns + isoCoordinates.y]->getCoordinates().height;
   int newTileID = -2; // set to -2 to determine if it's necessary to set a new tile ID
 
 
-  int x = isoCoordinates.getX();
-  int y = isoCoordinates.getY();
+  int x = isoCoordinates.x;
+  int y = isoCoordinates.y;
 
   std::pair<int, int> adjecantCellCoordinates[9] = {
     std::make_pair(x - 1, y - 1),    // 6 = 2^6 = 64  = BOTTOM LEFT
@@ -134,13 +134,13 @@ void vectorMatrix::determineTileIDOfCell(const Point& isoCoordinates)
   {
     if ( Resources::getTerrainEditMode() == Resources::TERRAIN_RAISE )
     {
-      increaseHeightOfCell(_cellMatrix[isoCoordinates.getX() * _columns + isoCoordinates.getY()]->getCoordinates());
+      increaseHeightOfCell(_cellMatrix[isoCoordinates.x * _columns + isoCoordinates.y]->getCoordinates());
     }
     else if ( Resources::getTerrainEditMode() == Resources::TERRAIN_LOWER )
     {
       for (auto it : adjecantCellCoordinates)
       {
-        if ( _cellMatrix[it.first * _columns + it.second]->getCoordinates().getHeight() > tileHeight
+        if ( _cellMatrix[it.first * _columns + it.second]->getCoordinates().height > tileHeight
         &&   _cellMatrix[it.first * _columns + it.second] )
         {
           decreaseHeightOfCell(_cellMatrix[it.first * _columns + it.second]->getCoordinates());
@@ -153,7 +153,7 @@ void vectorMatrix::determineTileIDOfCell(const Point& isoCoordinates)
 
   if ( newTileID != -2 )
   {
-    _cellMatrix[isoCoordinates.getX() * _columns + isoCoordinates.getY()]->setTileID(newTileID);
+    _cellMatrix[isoCoordinates.x * _columns + isoCoordinates.y]->setTileID(newTileID);
   }
   else
   {
@@ -164,8 +164,8 @@ void vectorMatrix::determineTileIDOfCell(const Point& isoCoordinates)
 unsigned int vectorMatrix::getElevatedNeighborBitmask(const Point& isoCoordinates)
 {
   unsigned int bitmask = 0;
-  int x = isoCoordinates.getX();
-  int y = isoCoordinates.getY();
+  int x = isoCoordinates.x;
+  int y = isoCoordinates.y;
 
 
   std::pair<int, int> adjecantCellCoordinates[8] = { 
@@ -184,7 +184,7 @@ unsigned int vectorMatrix::getElevatedNeighborBitmask(const Point& isoCoordinate
   {
     if (it.first >= 0 && it.first < _rows && it.second >= 0 && it.second < _columns)
     {
-      if ( _cellMatrix[it.first * _columns + it.second]->getCoordinates().getHeight() > _cellMatrix[x *_columns + y]->getCoordinates().getHeight()
+      if ( _cellMatrix[it.first * _columns + it.second]->getCoordinates().height > _cellMatrix[x *_columns + y]->getCoordinates().height
       &&   _cellMatrix[it.first * _columns + it.second] )
       {
         // for each found tile add 2 ^ i to the bitmask
@@ -198,8 +198,8 @@ unsigned int vectorMatrix::getElevatedNeighborBitmask(const Point& isoCoordinate
 
 std::vector<std::shared_ptr<Cell> > vectorMatrix::getNeighbors(const Point &isoCoordinates)
 {
-  int x = isoCoordinates.getX();
-  int y = isoCoordinates.getY();
+  int x = isoCoordinates.x;
+  int y = isoCoordinates.y;
 
   std::vector<std::shared_ptr<Cell> > neighborCells;
   neighborCells.reserve(9);

--- a/src/engine/basics/vectorMatrix.hxx
+++ b/src/engine/basics/vectorMatrix.hxx
@@ -12,7 +12,7 @@ public:
   vectorMatrix(int columns, int rows);
   ~vectorMatrix() = default;
   
-  void addCell(int x, int y, int z) { _cellMatrix[x * _columns + y] = std::make_shared<Cell>(Point(x, y, z)); };
+  void addCell(int x, int y, int z) { _cellMatrix[x * _columns + y] = std::make_shared<Cell>(Point{x, y, z, 0}); };
   std::shared_ptr<Cell> getCell(int x, int y) { return _cellMatrix[x * _columns + y]; };
 
   /** \brief Initialize the vecotrMatrix with cell objects
@@ -40,7 +40,7 @@ public:
     * [ 0 0 0 0  0  0  0  0 ]
     * @param isoCoordinates isometric coordinates of the tile whose neighbors should be retrieved
     * @returns  Uint that stores the elevated neighbor tiles
-  ´ */
+  ï¿½ */
   unsigned int getElevatedNeighborBitmask(const Point& isoCoordinates);
 
   /**\brief Get neighbor Cell Objects

--- a/src/engine/cell.cxx
+++ b/src/engine/cell.cxx
@@ -7,22 +7,22 @@ Cell::Cell(const Point& isoCoordinates) : _isoCoordinates(isoCoordinates), _tile
 
 void Cell::increaseHeightOfCell()
 {
-  int height = _isoCoordinates.getHeight();
+  int height = _isoCoordinates.height;
 
   if ( height < _maxCellHeight )
   {
-    _isoCoordinates.setHeight(_isoCoordinates.getHeight() + 1);
+    _isoCoordinates.height++;
     _sprite->setTileIsoCoordinates(_isoCoordinates);
   }
 }
 
 void Cell::decreaseHeightOfCell()
 {
-  int height = _isoCoordinates.getHeight();
+  int height = _isoCoordinates.height;
   
   if ( height > 0 )
   {
-    _isoCoordinates.setHeight(height - 1);
+    _isoCoordinates.height--;
     _sprite->setTileIsoCoordinates(_isoCoordinates);
   }
 }

--- a/src/engine/engine.cxx
+++ b/src/engine/engine.cxx
@@ -18,7 +18,7 @@ Engine::Engine()
   _screen_width = Resources::settings.screenWidth;
 
   // set camera to map center
-  _centerIsoCoordinates = Point(_map_size / 2, _map_size / 2);
+  _centerIsoCoordinates = Point{_map_size / 2, _map_size / 2, 0, 0};
   centerScreenOnPoint(_centerIsoCoordinates);
 }
 
@@ -44,17 +44,17 @@ void Engine::centerScreenOnPoint(const Point& isoCoordinates)
     int x, y;
     _zoomLevel = Resources::getZoomLevel();
 
-    x = static_cast<int>((screenCoordinates.getX() + (_tileSize*_zoomLevel)*0.5) - _screen_width * 0.5);
-    y = static_cast<int>((screenCoordinates.getY() + (_tileSize*_zoomLevel)*0.75) - _screen_height * 0.5);
+    x = static_cast<int>((screenCoordinates.x + (_tileSize*_zoomLevel)*0.5) - _screen_width * 0.5);
+    y = static_cast<int>((screenCoordinates.y + (_tileSize*_zoomLevel)*0.75) - _screen_height * 0.5);
   
-    Resources::setCameraOffset(Point(x, y));
+    Resources::setCameraOffset(Point{x, y, 0, 0});
   }
 }
 
 bool Engine::isPointWithinBoundaries(const Point& isoCoordinates)
 {
-  if (( isoCoordinates.getX() >= 0 && isoCoordinates.getX() <= _map_size ) 
-  && (  isoCoordinates.getY() >= 0 && isoCoordinates.getY() <= _map_size ))
+  if (( isoCoordinates.x >= 0 && isoCoordinates.x <= _map_size )
+  && (  isoCoordinates.y >= 0 && isoCoordinates.y <= _map_size ))
     return true;
   else
     return false;
@@ -96,7 +96,7 @@ void Engine::decreaseZoomLevel()
 
 Point Engine::findCellAt(const Point& screenCoordinates)
 {
-  Point foundCoordinates = Point(-1, -1);
+  Point foundCoordinates {-1, -1, 0, 0};
  
   // check all cells of the map to find the clicked point
   for (int x = 0; x <= _map_size; x++)
@@ -107,8 +107,8 @@ Point Engine::findCellAt(const Point& screenCoordinates)
 
       SDL_Rect spriteRect = currentCell->getSprite()->getTextureInformation();
 
-      int clickedX = screenCoordinates.getX() ;
-      int clickedY = screenCoordinates.getY() ;
+      int clickedX = screenCoordinates.x ;
+      int clickedY = screenCoordinates.y ;
 
       int spriteX = spriteRect.x;
       int spriteY = spriteRect.y;
@@ -126,7 +126,7 @@ Point Engine::findCellAt(const Point& screenCoordinates)
         // Check if the clicked Sprite is not transparent (we hit a point within the pixel)
         if (TextureManager::Instance().GetPixelColor(currentCell->getTileID(), pixelX, pixelY).a != SDL_ALPHA_TRANSPARENT)
         {
-          if (foundCoordinates.getZ() < currentCell->getCoordinates().getZ())
+          if (foundCoordinates.z < currentCell->getCoordinates().z)
           {
             foundCoordinates = currentCell->getCoordinates();
           }

--- a/src/engine/sprite.cxx
+++ b/src/engine/sprite.cxx
@@ -18,10 +18,10 @@ void Sprite::render()
   int screen_height = Resources::settings.screenHeight;
 
   //Render only whats visible
-  if (( _screenCoordinates.getX() >= 0 - offscreenTolerance )
-  ||  ( _screenCoordinates.getX() + tileSize <= screen_width + offscreenTolerance )
-  ||  ( _screenCoordinates.getY() >= 0 - offscreenTolerance )
-  ||  ( _screenCoordinates.getY() + tileSize <= screen_height + offscreenTolerance ))
+  if (( _screenCoordinates.x >= 0 - offscreenTolerance )
+  ||  ( _screenCoordinates.x + tileSize <= screen_width + offscreenTolerance )
+  ||  ( _screenCoordinates.y >= 0 - offscreenTolerance )
+  ||  ( _screenCoordinates.y + tileSize <= screen_height + offscreenTolerance ))
   {
     renderTexture(tileSize, tileSize);
   }
@@ -29,8 +29,8 @@ void Sprite::render()
 
 void Sprite::renderTexture(int w, int h)
 {
-  _destRect.x = _screenCoordinates.getX();
-  _destRect.y = _screenCoordinates.getY();
+  _destRect.x = _screenCoordinates.x;
+  _destRect.y = _screenCoordinates.y;
   _destRect.w = w;
   _destRect.h = h;
   SDL_RenderCopy(_renderer, _texture, nullptr, &_destRect);

--- a/src/engine/ui/uiElement.cxx
+++ b/src/engine/ui/uiElement.cxx
@@ -1,16 +1,16 @@
 #include "uiElement.hxx"
 
-UiElement::UiElement(int x, int y, int uiSpriteID, int groupID, int actionID, int parentOfGroup) : _screenCoordinates(Point(x,y)), _groupID(groupID), _actionID(actionID), _parentOf(parentOfGroup), _uiElementType("ImageButton")
+UiElement::UiElement(int x, int y, int uiSpriteID, int groupID, int actionID, int parentOfGroup) : _screenCoordinates({x, y, 0, 0}), _groupID(groupID), _actionID(actionID), _parentOf(parentOfGroup), _uiElementType("ImageButton")
 {
   _texture = TextureManager::Instance().getUITexture(uiSpriteID);
 }
 
-UiElement::UiElement(int x, int y, const std::string& text, int groupID, int actionID, int parentOfGroup) : _screenCoordinates(Point(x, y))
+UiElement::UiElement(int x, int y, const std::string& text, int groupID, int actionID, int parentOfGroup) : _screenCoordinates({x, y, 0, 0})
 {
   drawText(text, _color);
 }
 
-UiElement::UiElement(int x, int y, int w, int h, int groupID, int actionID, int parentOfGroup) : _screenCoordinates(Point(x, y)), _width(w), _height(h)
+UiElement::UiElement(int x, int y, int w, int h, int groupID, int actionID, int parentOfGroup) : _screenCoordinates({x, y, 0, 0}), _width(w), _height(h)
 {
 
 }
@@ -27,8 +27,8 @@ void UiElement::changeTexture(int tileID)
 
 void UiElement::renderTexture(int w, int h)
 {
-  _destRect.x = _screenCoordinates.getX();
-  _destRect.y = _screenCoordinates.getY();
+  _destRect.x = _screenCoordinates.x;
+  _destRect.y = _screenCoordinates.y;
   _destRect.w = w;
   _destRect.h = h;
   SDL_RenderCopy(_renderer, _texture, nullptr, &_destRect);

--- a/src/game.cxx
+++ b/src/game.cxx
@@ -84,7 +84,7 @@ int main(int, char**)
             LOG().timerStart();
             for (int i = 0; i <= Resources::settings.maxElevationHeight; i++)
             {
-              engine.increaseHeightOfCell(Point(64, 64));
+              engine.increaseHeightOfCell(Point{64, 64, 0, 0});
             }
             LOG().timerEnd();
 
@@ -100,7 +100,7 @@ int main(int, char**)
         }
         
 
-        mouseCoords.setCoords(event.button.x, event.button.y);
+        mouseCoords = Point{event.button.x, event.button.y, 0, 0};
         clickCoords = Resources::convertScreenToIsoCoordinates(mouseCoords);
         if ( event.button.button == SDL_BUTTON_LEFT )
         {
@@ -113,7 +113,7 @@ int main(int, char**)
               engine.decreaseHeightOfCell(clickCoords);
             }
             else
-              LOG() << "CLICKED - Iso Coords: " << clickCoords.getX() << ", " << clickCoords.getY();
+              LOG() << "CLICKED - Iso Coords: " << clickCoords.x << ", " << clickCoords.y;
           }
         }
         else if ( event.button.button == SDL_BUTTON_RIGHT )


### PR DESCRIPTION
This changes Point into a simple struct. This allows us to use brace initialization to construct its elements. e.g., Point{1, 2, 3, 4} would set x to 1, y to 2, z to 3, and height to 4. This also means that, if a function returns a Point, you can simply specific the braces {1, 2, 3, 4} without having to say Point.